### PR TITLE
feat: Adding Cloud Workflow Template to export Vector Embeddings from Spanner to Vertex Vector Search

### DIFF
--- a/vertex-vector-search/workflows/batch-export.yaml
+++ b/vertex-vector-search/workflows/batch-export.yaml
@@ -25,11 +25,6 @@ main:
                   - condition: ${not ("location" in params.dataflow)}
                     assign:
                       - params.dataflow.location: ${params.location}
-          - spanner_location:
-              switch:
-                  - condition: ${not ("location" in params.spanner)}
-                    assign:
-                      - params.spanner.location: ${params.location}
           - vertex_location:
               switch:
                   - condition: ${not ("location" in params.vertex)}
@@ -37,7 +32,7 @@ main:
                       - params.vertex.location: ${params.location}
     - check_vector_search_index_exists:
           call: http.request
-          args: 
+          args:
             url: ${"https://" + params.vertex.location + "-aiplatform.googleapis.com/v1/projects/" + params.vertex.project_id + "/locations/" + params.vertex.location + "/indexes/" + params.vertex.vector_search_index_id}
             method: GET
             auth:
@@ -49,11 +44,11 @@ main:
     - log_timestamp:
         call: sys.log
         args:
-          text: ${"Spanner Version Time - " + current_timestamp}
+          text: ${"Spanner Version Time chosen for exporting data is " + current_timestamp}
     - initialize_dataflow_job_name_and_gcs_folder:
         assign:
           - spanner_export_job_name: ${params.dataflow.job_name_prefix + "_" + current_timestamp}
-          - embeddings_output_folder: ${params.gcs.output_folder + current_timestamp + "/"}  
+          - embeddings_output_folder: ${params.gcs.output_folder + "embeddings-" + current_timestamp + "/"}
     - initialize_dataflow_job_variables:
         steps:
           - max_workers:
@@ -74,14 +69,14 @@ main:
     - log_gcs_folder_path:
         call: sys.log
         args:
-          text: ${"Exporting Vector Embeddings to following gcs folder - " + embeddings_output_folder}
+          text: ${"Exporting Vector Embeddings to gcs folder - " + embeddings_output_folder}
     - dataflow_spanner_export_job:
         call: googleapis.dataflow.v1b3.projects.locations.templates.create
         args:
           projectId: ${params.dataflow.project_id}
           location: ${params.dataflow.location}
           body:
-            jobName: ${spanner_export_job_name} 
+            jobName: ${spanner_export_job_name}
             parameters:
               spannerProjectId: ${params.spanner.project_id}
               spannerInstanceId: ${params.spanner.instance_id}
@@ -106,58 +101,62 @@ main:
     - log_dataflow_job:
         call: sys.log
         args:
-          text: ${"Dataflow Job dashboard - " + "https://console.cloud.google.com/dataflow/jobs/" + params.dataflow.location + "/" + dataflow_export_job_id}
-    - trigger_vector_search_index_rebuild:
-        call: http.request
-        args:
-            url: ${"https://" + params.vertex.location + "-aiplatform.googleapis.com/v1/projects/" + params.vertex.project_id + "/locations/" + params.vertex.location + "/indexes/" + params.vertex.vector_search_index_id}
-            method: PATCH
-            body:
-              metadata:
-                contentsDeltaUri: ${embeddings_output_folder}
-                isCompleteOverwrite: true
-            auth:
-              type: OAuth2
-        result: index_rebuild_response
-    - set_vector_search_index_rebuild_operation:
+          text: ${"Export of data to gcs complete. You can view the job details at " + "https://console.cloud.google.com/dataflow/jobs/" + params.dataflow.location + "/" + dataflow_export_job_id}
+    - trigger_vector_search_index_update:
+        try:
+          call: http.request
+          args:
+              url: ${"https://" + params.vertex.location + "-aiplatform.googleapis.com/v1/projects/" + params.vertex.project_id + "/locations/" + params.vertex.location + "/indexes/" + params.vertex.vector_search_index_id}
+              method: PATCH
+              body:
+                metadata:
+                  contentsDeltaUri: ${embeddings_output_folder}
+                  isCompleteOverwrite: true
+              auth:
+                type: OAuth2
+          result: index_update_response
+        retry: ${http.default_retry_non_idempotent}
+    - set_vector_search_index_update_operation:
         assign:
-          - vector_search_operation: ${index_rebuild_response.body.name}
-          - vector_search_index_rebuild_completed: False
+          - vector_search_operation: ${index_update_response.body.name}
+          - vector_search_index_update_completed: False
     - log_vector_search_operation:
         call: sys.log
         args:
-          text: ${vector_search_operation}
-    - polling_vector_search_index_rebuild_operation:
+          text: ${"Vector search index update operation started - " + vector_search_operation}
+    - polling_vector_search_index_update_operation:
         try:
-          steps: 
-            - index_rebuild_lro_url:
-                call: http.request
-                args: 
-                  url: ${"https://" + params.vertex.location + "-aiplatform.googleapis.com/v1/" + vector_search_operation}
-                  method: GET
-                  auth:
-                    type: OAuth2
-                result: index_rebuild_operation_response
+          steps:
+            - index_update_lro_url:
+                try:
+                  call: http.request
+                  args:
+                    url: ${"https://" + params.vertex.location + "-aiplatform.googleapis.com/v1/" + vector_search_operation}
+                    method: GET
+                    auth:
+                      type: OAuth2
+                  result: index_update_operation_response
+                retry: ${http.default_retry}
             - index_state:
                 switch:
-                    - condition: ${"done" in index_rebuild_operation_response.body}
+                    - condition: ${"done" in index_update_operation_response.body}
                       assign:
-                        - vector_search_index_rebuild_completed:  ${index_rebuild_operation_response.body.done}
+                        - vector_search_index_update_completed:  ${index_update_operation_response.body.done}
             - log_index_state:
                 switch:
-                      - condition: ${vector_search_index_rebuild_completed != true}
+                      - condition: ${vector_search_index_update_completed != true}
                         call: sys.log
                         args:
-                          text: ${"Vertex Vector Search Index rebuild is in progress."}
-                      - condition: ${vector_search_index_rebuild_completed == true}
+                          text: ${"Vertex Vector Search Index update is in progress."}
+                      - condition: ${vector_search_index_update_completed == true}
                         call: sys.log
                         args:
-                          text: ${"Vertex Vector Search Index rebuild completed."}         
+                          text: ${"Vertex Vector Search Index update completed."}
             - induce_backoff_retry_if_index_build_not_completed:
                 switch:
-                  - condition: ${vector_search_index_rebuild_completed != true}
+                  - condition: ${vector_search_index_update_completed != true}
                     raise: False
-            
+
         retry:
           predicate: ${job_state_predicate}
           max_retries: 1000
@@ -167,17 +166,17 @@ main:
             multiplier: 1
     - workflow_output:
         switch:
-            - condition: ${"error" in index_rebuild_operation_response.body}
-              return: ${index_rebuild_operation_response.body.error}
-            - condition: ${"response" in index_rebuild_operation_response.body}
-              return: ${index_rebuild_operation_response.body.response}
+            - condition: ${"error" in index_update_operation_response.body}
+              return: ${index_update_operation_response.body.error}
+            - condition: ${"response" in index_update_operation_response.body}
+              return: ${index_update_operation_response.body.response}
 
 job_state_predicate:
-  params: [vector_search_index_rebuild_completed]  
+  params: [vector_search_index_update_completed]
   steps:
     - condition_to_retry:
         switch:
-          - condition: ${vector_search_index_rebuild_completed != true}
+          - condition: ${vector_search_index_update_completed != true}
             return: True # do retry
     - otherwise:
         return: False # stop retrying


### PR DESCRIPTION
Adding a Cloud Workflow configuration file which when executed will export vector embeddings data from Spanner to Vertex Vector Search. 
At macro level, workflow incudes following steps: 

1. Trigger a dataflow job to export embeddings to GCS. 
2. Trigger Vertex Vector Search Index rebuild. 
3. Polling the Vertex Vector Search API to know the status of long running operation. 